### PR TITLE
docs + fix(repo): authority/SDK docs, PDA guarding, Vercel build fixes

### DIFF
--- a/apps/landing/lib/vault.ts
+++ b/apps/landing/lib/vault.ts
@@ -109,11 +109,8 @@ function u64LE(n: bigint): Uint8Array {
   return buf
 }
 
-function concat(...parts: Uint8Array[]): Uint8Array {
-  const out = new Uint8Array(parts.reduce((s, p) => s + p.length, 0))
-  let offset = 0
-  for (const p of parts) { out.set(p, offset); offset += p.length }
-  return out
+function concat(...parts: Uint8Array[]): Buffer {
+  return Buffer.concat(parts.map(p => Buffer.from(p)))
 }
 
 export function buildDepositIx(

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -36,5 +36,12 @@
     "postcss": "^8.5.0",
     "tailwindcss": "^4.2",
     "typescript": "^5.7.0"
+  },
+  "optionalDependencies": {
+    "@img/sharp-libvips-linux-x64": "1.2.4",
+    "@img/sharp-linux-x64": "0.34.5",
+    "@napi-rs/simple-git-linux-x64-gnu": "0.1.22",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
+    "lightningcss-linux-x64-gnu": "1.32.0"
   }
 }

--- a/docs/content/_meta.ts
+++ b/docs/content/_meta.ts
@@ -2,6 +2,8 @@ export default {
   index:        "How it works",
   quickstart:   "Quickstart",
   integration:  "Integration",
+  authority:    "Trana Authority",
+  sdk:          "SDK Reference",
   passkeys:     "Passkey management",
   architecture: "Architecture",
   glossary:     "Glossary",

--- a/docs/content/architecture.mdx
+++ b/docs/content/architecture.mdx
@@ -24,9 +24,13 @@ Trana has three layers. The Solana runtime ties them together — all three exec
 
 ## Components
 
-### programs/guard — the authorization primitive
+### programs/trana_guard — the authorization primitive
 
-One deployed program. Five instructions.
+One deployed program. Seven instructions.
+
+`init_config` initializes the global `TranaConfig` PDA (fees, treasury, authority). Called once at deploy time.
+
+`update_config` updates fees or treasury address. Only callable by the config authority.
 
 `register_passkey` initializes the `PasskeyRegistry` PDA for a wallet and writes the first P-256 public key and credential ID. Only succeeds when the registry is empty — subsequent passkeys must be added via `add_passkey`.
 
@@ -37,6 +41,16 @@ One deployed program. Five instructions.
 `record_proof` is a data carrier. It holds WebAuthn binding bytes (`authenticatorData`, `clientDataJSON`, expiry, and policy) in instruction data and modifies no accounts.
 
 `enforce` is called by your program via CPI. It reads the two preceding instructions from the Instructions sysvar, verifies the P-256 signature against any key in the registry, checks the intent hash, and increments the nonce. If anything fails, the whole transaction reverts.
+
+### programs/trana_authority — upgrade authority protection
+
+Wraps the BPF Loader upgrade path behind the same passkey check. Three instructions.
+
+`register` creates an `AuthorityRecord` PDA for an `(owner, target)` pair. No passkey required. After calling this, the user transfers the real upgrade authority to the PDA via the Solana CLI.
+
+`execute_upgrade` upgrades the target program. Calls `trana_guard::cpi::enforce(Policy::Require)`, then invokes the BPF Loader with the PDA as the signing authority.
+
+`reclaim_authority` returns upgrade authority to a new pubkey and closes the PDA. Also guarded by passkey — even the escape hatch requires a second factor.
 
 ### packages/sdk — TypeScript client
 
@@ -49,6 +63,8 @@ packages/sdk/src/
 │   └── types.ts       TranaCluster, PasskeyHandle, Policy
 ├── guard/
 │   └── client.ts      TranaGuardClient — registerPasskey, addPasskey, removePasskey, buildProof
+├── authority/
+│   └── client.ts      TranaAuthorityClient — register, executeUpgrade, reclaimAuthority
 └── react/
     ├── provider.tsx          TranaProvider — context and deferred promise hub
     ├── modal.tsx             TranaModal — registration, confirmation, approval, error

--- a/docs/content/authority.mdx
+++ b/docs/content/authority.mdx
@@ -1,0 +1,240 @@
+# Trana Authority
+
+Secure any program's upgrade authority behind a passkey — without touching the target program.
+
+> `trana_authority` wraps the BPF Loader upgrade path in a PDA that requires a Touch ID tap. The target program is unchanged. Zero code changes required.
+
+---
+
+## When to use it
+
+| | `trana_guard` | `trana_authority` |
+|---|---|---|
+| **What you secure** | Individual instructions inside your program | The upgrade authority of any deployed program |
+| **Code changes to target** | 3 accounts + 1 CPI call | **None** |
+| **Works on programs you didn't write** | No | **Yes** |
+| **Best for** | Runtime policy enforcement | CI/CD and deploy key protection |
+
+Use `trana_guard` when you need instruction-level policies (e.g. "require biometric for withdrawals over 1 SOL"). Use `trana_authority` when you want to protect the upgrade process for any program — including one you didn't write.
+
+---
+
+## How it works
+
+```
+Before:
+  wallet_keypair ──► bpf_loader::upgrade()   (anyone with the key can upgrade)
+
+After:
+  wallet_keypair ──► trana_authority::execute_upgrade()
+                              │
+                              ├── trana_guard::cpi::enforce()   ← passkey required
+                              │
+                              └── bpf_loader::upgrade()          ← PDA signs via CPI
+```
+
+The `trana_authority` PDA becomes the real upgrade authority. The wallet key alone is insufficient — `execute_upgrade` only proceeds if `trana_guard::cpi::enforce()` passes.
+
+---
+
+## Setup
+
+### 1. Register the authority PDA
+
+```ts
+import { TranaAuthorityClient } from "@tranaprotocol/sdk/authority"
+
+const client = new TranaAuthorityClient({ connection, cluster: "devnet" })
+
+const registerIx = await client.register({
+  owner:  walletPubkey,
+  target: programPubkey,   // the program you want to protect
+})
+
+const tx = new Transaction().add(registerIx)
+await sendAndConfirm(tx)
+```
+
+This creates an `AuthorityRecord` PDA at seeds `["trana-authority", owner, target]`.
+
+### 2. Transfer the upgrade authority
+
+After the PDA is created, hand the BPF Loader authority to it:
+
+```bash
+solana program set-upgrade-authority <PROGRAM_ID> \
+  --new-upgrade-authority <AUTHORITY_PDA>
+```
+
+Derive `<AUTHORITY_PDA>`:
+
+```ts
+const [pda] = await client.recordPda(walletPubkey, programPubkey)
+console.log("Authority PDA:", pda.toBase58())
+```
+
+From this point, the wallet key alone cannot upgrade the program.
+
+---
+
+## Upgrading a program
+
+Upgrading requires a passkey proof. The SDK's `authorizeAndSend` handles everything automatically.
+
+```ts
+import { TranaAuthorityClient } from "@tranaprotocol/sdk/authority"
+
+const client = new TranaAuthorityClient({ connection, cluster: "devnet" })
+
+const upgradeIx = await client.executeUpgrade({
+  owner:       walletPubkey,
+  program:     programPubkey,
+  programData: programDataPubkey,   // derived from program address
+  buffer:      bufferPubkey,        // uploaded .so buffer account
+  spill:       walletPubkey,        // rent reclaim destination
+})
+
+// authorizeAndSend prepends the (secp256r1, record_proof) pair automatically
+const { authorizeAndSend } = useTrana()
+await authorizeAndSend({
+  instruction: upgradeIx,
+  label: "Upgrade program",
+})
+```
+
+### Transaction shape
+
+```
+ix[N-2]: secp256r1 precompile     native P-256 sig verify
+ix[N-1]: trana_guard::record_proof
+ix[N]:   trana_authority::execute_upgrade  → enforce() → bpf_loader::upgrade()
+```
+
+All three execute atomically. If the passkey check fails, the upgrade is reverted.
+
+---
+
+## Reclaiming the authority
+
+To move upgrade authority back to a different key (e.g. a new multisig), use `reclaim_authority`. This operation also requires a passkey — even the escape hatch is second-factor protected.
+
+```ts
+const reclaimIx = await client.reclaimAuthority({
+  owner:        walletPubkey,
+  target:       programPubkey,
+  programData:  programDataPubkey,
+  newAuthority: newAuthorityPubkey,  // where authority goes after reclaim
+})
+
+await authorizeAndSend({
+  instruction: reclaimIx,
+  label: "Reclaim upgrade authority",
+})
+```
+
+`reclaim_authority` closes the `AuthorityRecord` PDA and returns rent to the owner.
+
+---
+
+## Program account
+
+### `AuthorityRecord`
+
+PDA seeds: `[b"trana-authority", owner, target]`
+
+| Field | Type | Description |
+|---|---|---|
+| `owner` | `Pubkey` | Wallet that controls this record |
+| `target` | `Pubkey` | Program being protected |
+| `bump` | `u8` | PDA bump seed |
+
+One PDA per `(owner, target)` pair. One wallet can protect multiple programs independently.
+
+---
+
+## Instructions
+
+### `register`
+
+Creates the `AuthorityRecord` PDA. No passkey required — wallet signature only.
+
+Call this once before transferring upgrade authority to the PDA.
+
+| Account | Role |
+|---|---|
+| `owner` | Signer — pays for PDA creation |
+| `target` | Program being protected (read-only) |
+| `authority_record` | New PDA (`init`) |
+| `system_program` | Required for account creation |
+
+---
+
+### `execute_upgrade`
+
+Upgrades the target program. Requires a passkey proof via `trana_guard::cpi::enforce(Policy::Require)`.
+
+| Account | Role |
+|---|---|
+| `owner` | Signer |
+| `authority_record` | `AuthorityRecord` PDA (`has_one = owner`) |
+| `program` | Program account being upgraded |
+| `program_data` | Program data account |
+| `buffer` | Uploaded `.so` buffer |
+| `spill` | Rent reclaim destination (usually `owner`) |
+| `bpf_loader` | `BPFLoaderUpgradeable111...` |
+| `trana_guard_program` | Guard program |
+| `trana_registry` | `PasskeyRegistry` PDA for `owner` |
+| `trana_instructions` | Instructions sysvar |
+
+---
+
+### `reclaim_authority`
+
+Returns upgrade authority to a new pubkey and closes the `AuthorityRecord`. Requires passkey.
+
+| Account | Role |
+|---|---|
+| `owner` | Signer |
+| `authority_record` | `AuthorityRecord` PDA (closed on success) |
+| `program` | Program whose authority is being reclaimed |
+| `program_data` | Program data account |
+| `new_authority` | Where upgrade authority will be transferred |
+| `bpf_loader` | `BPFLoaderUpgradeable111...` |
+| `trana_guard_program` | Guard program |
+| `trana_registry` | `PasskeyRegistry` PDA for `owner` |
+| `trana_instructions` | Instructions sysvar |
+
+---
+
+## Program IDs
+
+| Cluster | Program ID |
+|---|---|
+| Mainnet | `KoXvrg4DBLKa5U6LCUpWXJE1FHYqwaozqDqDcBXvGEE` |
+| Devnet | `TRNA8iyPm9AuBGiTeSirJm6F4jsxvq66LqfFeU7G4AN` |
+
+---
+
+## Security properties
+
+**Leaked deploy key cannot upgrade alone.** The upgrade authority is the PDA, not the wallet key. The wallet key can call `execute_upgrade`, but the call reverts unless the passkey proof passes.
+
+**CI pipeline compromise is blocked.** An automated pipeline that exfiltrates the deploy key still cannot upgrade — there is no passkey to sign the proof.
+
+**Reclaim is equally protected.** `reclaim_authority` is gated by the same passkey check. An attacker who controls the wallet key cannot silently move authority away.
+
+**Inherits guard improvements automatically.** `trana_authority` delegates security entirely to `trana_guard::cpi::enforce()`. Any improvement to the guard (new policy types, key recovery) applies to authority protection without a redeployment.
+
+---
+
+## Comparison to multisig
+
+| | Squads Multisig | Trana Authority |
+|---|---|---|
+| Second factor type | More signatures (same kind) | Different factor (biometric device) |
+| Setup | Create multisig, add members | Register PDA, transfer authority |
+| Execution | Collect M-of-N signatures | One Touch ID tap |
+| Signing ceremony | Yes — coordinate signers | No |
+| Leaked member key | Threshold still holds | Key alone is useless |
+
+They are complementary. Squads and Trana together give you multisig threshold **and** a biometric check for every signer.

--- a/docs/content/authority.mdx
+++ b/docs/content/authority.mdx
@@ -238,3 +238,66 @@ Returns upgrade authority to a new pubkey and closes the `AuthorityRecord`. Requ
 | Leaked member key | Threshold still holds | Key alone is useless |
 
 They are complementary. Squads and Trana together give you multisig threshold **and** a biometric check for every signer.
+
+---
+
+## Upcoming — PDA guarding
+
+> **Status: not yet released.** This section describes a planned extension to `trana_authority`.
+
+Today `trana_authority` secures one specific CPI path: BPF Loader upgrades. The next primitive generalises this to **any PDA that acts as a signing authority**.
+
+### The problem
+
+Many programs use a PDA as their privileged signer — a token mint authority, a DAO treasury, a price-feed update authority, a protocol fee collector. Whoever controls the wallet that owns that PDA controls the privileged action. There is currently no way to require a biometric check before the PDA signs a CPI, without modifying the target program.
+
+### What PDA guarding adds
+
+A generalised `trana_authority` variant that can act as the authority for **any PDA-signed CPI**:
+
+```
+Before:
+  wallet_keypair ──► your_program::privileged_action()
+                           └── PDA signs CPI   (any CPI)
+
+After:
+  wallet_keypair ──► trana_authority::execute_cpi()
+                           │
+                           ├── trana_guard::cpi::enforce()   ← passkey required
+                           │
+                           └── your_program::privileged_action()
+                                     └── PDA signs CPI
+```
+
+### Planned use cases
+
+| Authority type | Example |
+|---|---|
+| Token mint authority | Require passkey before minting new supply |
+| DAO treasury signer | Require passkey before treasury disbursements |
+| Protocol fee recipient | Require passkey before changing fee destination |
+| Oracle update authority | Require passkey before publishing a price feed |
+| Program config authority | Require passkey before updating protocol parameters |
+
+### Planned design
+
+The `AuthorityRecord` PDA would carry a `cpi_target` field alongside `owner` and `target`. An `execute_cpi` instruction would:
+
+1. Verify the passkey proof via `trana_guard::cpi::enforce()`
+2. Deserialize a caller-supplied CPI descriptor (program ID, accounts, data)
+3. Call `invoke_signed` with the `AuthorityRecord` PDA as the signer
+
+Because the PDA seeds include `owner` and `target`, each protected authority gets its own independent PDA — one wallet can protect multiple distinct authorities without cross-contamination.
+
+### How it differs from `trana_guard`
+
+| | `trana_guard` | PDA guarding (upcoming) |
+|---|---|---|
+| Target program changes | Yes — 3 accounts + 1 CPI call | **No** |
+| Protects arbitrary CPIs | No — only `enforce()` call sites | **Yes** |
+| Policy support | All four policies | `Require` initially |
+| Works on unmodifiable programs | No | **Yes** |
+
+### Timeline
+
+PDA guarding is under design. It depends on finalising the CPI descriptor format and the account validation model. Follow the [Trana repository](https://github.com/beharefe/trana) for updates.

--- a/docs/content/glossary.mdx
+++ b/docs/content/glossary.mdx
@@ -131,3 +131,51 @@ The enum passed to `guard::cpi::enforce()`. Four variants: `Require` (always req
 ### param_offset
 
 The byte offset of a `u64` parameter inside the protected instruction's data, measured **after** the 8-byte Anchor discriminator. Used with `Policy::Limit` to tell the guard which field to read. For `fn action(ctx, amount: u64)` the offset is `0`. For `fn action(ctx, recipient: Pubkey, amount: u64)` the offset is `32`. Compute it by summing the byte sizes of all parameters before the target `u64`: `Pubkey`=32, `u64`=8, `u32`=4, `bool`/`u8`=1.
+
+---
+
+### trana_authority
+
+The second Trana program. Wraps the BPF Loader upgrade path so any program's upgrade authority can be secured with a passkey, without modifying the target program. See [Trana Authority](/authority).
+
+---
+
+### AuthorityRecord
+
+The on-chain PDA created by `trana_authority::register`. Seeds: `["trana-authority", owner, target]`. Stores `owner` (the wallet controlling the PDA) and `target` (the program being protected). One PDA per `(owner, target)` pair.
+
+---
+
+### execute_upgrade
+
+The `trana_authority` instruction that upgrades a program. Calls `trana_guard::cpi::enforce(Policy::Require)` before invoking the BPF Loader. The `AuthorityRecord` PDA signs the BPF Loader CPI — the wallet key alone cannot trigger an upgrade.
+
+---
+
+### reclaim_authority
+
+The `trana_authority` instruction that transfers upgrade authority from the `AuthorityRecord` PDA to a new pubkey and closes the PDA. Also gated by `trana_guard::cpi::enforce(Policy::Require)` — even the escape hatch requires a passkey.
+
+---
+
+### BPF Loader Upgradeable
+
+The Solana system program (`BPFLoaderUpgradeab1e11111111111111111111111`) responsible for deploying and upgrading programs. `trana_authority` uses this program via CPI, with the `AuthorityRecord` PDA as the signing authority.
+
+---
+
+### TranaConfig
+
+The global fee configuration PDA, seeded at `["config"]` on the guard program. Stores `authority`, `treasury`, `register_fee`, and `add_key_fee`. Anyone can read it on-chain to verify what fees are charged. Only the `authority` can update it via `update_config`.
+
+---
+
+### init_config
+
+The one-time setup instruction that creates the `TranaConfig` PDA. Called once at guard program deploy time by the program authority.
+
+---
+
+### update_config
+
+The guard instruction for changing fees or the treasury address. Only callable by the pubkey stored in `TranaConfig.authority`.

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -15,6 +15,8 @@ Passkey-enforced authorization for Solana programs. Two primitives. No backend r
 | **Works on existing programs** | No | **Yes** |
 | **Best for** | Runtime policies — withdrawals, transfers, config | Deploy key protection, CI/CD security |
 
+**Upcoming:** PDA guarding will extend `trana_authority` to any PDA-signed CPI — token mint authorities, DAO treasuries, protocol config signers — without touching the target program. See [Trana Authority — PDA guarding](/authority#upcoming--pda-guarding).
+
 ---
 
 ## How it works

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -1,25 +1,28 @@
 # Stolen keys can't drain guarded accounts.
 
-Secure your program with one CPI call.
+Passkey-enforced authorization for Solana programs. Two primitives. No backend required.
 
 > Any instruction that calls `guard::cpi::enforce()` cannot execute unless the wallet's registered passkey signed a hash that exactly describes this transaction.
 
 ---
 
-## The program requires your passkey. Not just your signature.
+## Two programs. Full stack.
 
-Wallet signing is all-or-nothing. Trana adds a second check at execution — inside the instruction itself.
-
-Proofs are tied to the exact accounts and params. They expire in 120 seconds. No backend required.
+| | `trana_guard` | `trana_authority` |
+|---|---|---|
+| **What it protects** | Individual instructions inside your program | Upgrade authority of any deployed program |
+| **Code changes required** | 3 accounts + 1 CPI call | **None** |
+| **Works on existing programs** | No | **Yes** |
+| **Best for** | Runtime policies — withdrawals, transfers, config | Deploy key protection, CI/CD security |
 
 ---
 
 ## How it works
 
 ```
-ix[0]:  secp256r1 precompile   ← Solana verifies the P-256 signature natively
-ix[1]:  guard::record_proof    ← carries WebAuthn authenticatorData + clientDataJSON
-ix[2]:  your_program::action   → calls guard::cpi::enforce() internally
+ix[N-2]:  secp256r1 precompile   ← Solana verifies the P-256 signature natively
+ix[N-1]:  guard::record_proof    ← carries WebAuthn authenticatorData + clientDataJSON
+ix[N]:    your_program::action   → calls guard::cpi::enforce() internally
 ```
 
 | | |
@@ -27,12 +30,31 @@ ix[2]:  your_program::action   → calls guard::cpi::enforce() internally
 | Onchain verification | SIMD-0075 secp256r1 precompile (mainnet since Feb 2025) |
 | Backend required | None — credentials stored in a PDA on-chain |
 | Supported devices | Touch ID, Face ID, YubiKey, Google Titan, Windows Hello |
-| Integration cost | 3 extra accounts + 1 helper method + 1 React hook |
+| Integration cost (`trana_guard`) | 3 extra accounts + 1 CPI call + 1 React hook |
+| Integration cost (`trana_authority`) | Register PDA + 1 CLI command |
 | Proof expiry | 120 seconds |
 
 ---
 
-- [Quickstart](/docs/quickstart) — add Trana to your program in 5 steps
-- [Integration](/docs/integration) — full Rust/Anchor + SDK reference
-- [Architecture](/docs/architecture) — how the three layers fit together
-- [Glossary](/docs/glossary) — definitions for every technical term
+## Policies
+
+The guard supports four enforcement modes:
+
+| Policy | Fires when |
+|---|---|
+| `trana.require` | Always |
+| `trana.limit` | A `u64` parameter in the instruction is ≥ a threshold |
+| `trana.not_before` | Current slot is before a given slot |
+| `trana.not_after` | Current slot is after a given slot |
+
+Conditional policies are no-ops when their condition is false — no proof needed.
+
+---
+
+- [Quickstart](/quickstart) — add Trana Guard to your program in 4 steps
+- [Integration](/integration) — full Rust/Anchor + TypeScript reference
+- [Trana Authority](/authority) — protect any program's upgrade authority
+- [SDK Reference](/sdk) — all exports, hooks, and client methods
+- [Passkey management](/passkeys) — add, remove, and recover keys
+- [Architecture](/architecture) — how the three layers fit together
+- [Glossary](/glossary) — definitions for every technical term

--- a/docs/content/sdk.mdx
+++ b/docs/content/sdk.mdx
@@ -1,0 +1,533 @@
+# SDK Reference
+
+`@tranaprotocol/sdk` — TypeScript/React client for Trana Guard and Trana Authority.
+
+---
+
+## Installation
+
+```bash
+npm install @tranaprotocol/sdk
+```
+
+**Peer dependencies:** `@solana/web3.js`, `@coral-xyz/anchor`
+
+---
+
+## Package exports
+
+| Import path | Contents |
+|---|---|
+| `@tranaprotocol/sdk` | React hooks, provider, modal, core utilities |
+| `@tranaprotocol/sdk/guard` | `TranaGuardClient` |
+| `@tranaprotocol/sdk/authority` | `TranaAuthorityClient` |
+| `@tranaprotocol/sdk/testing` | Test utilities — **never import in production** |
+
+---
+
+## React integration
+
+### `TranaProvider`
+
+Wrap your application once. All `useTrana` calls below it share the same context.
+
+```tsx
+import { TranaProvider, TranaModal } from "@tranaprotocol/sdk"
+import { PublicKey } from "@solana/web3.js"
+
+const GUARD_ID = new PublicKey(process.env.NEXT_PUBLIC_TRANA_GUARD_PROGRAM_ID!)
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  return (
+    <TranaProvider config={{
+      tranaGuardProgramId: GUARD_ID,
+      policy:        "trana.limit",   // default policy for detectEnforcement fallback
+      expiryTtlSec:  120,             // proof TTL in seconds (default: 120)
+    }}>
+      {children}
+      <TranaModal />
+    </TranaProvider>
+  )
+}
+```
+
+`TranaModal` renders the registration flow, confirmation dialog, biometric prompt, and error states. Place it at the root so it can overlay anything.
+
+---
+
+### `useTrana`
+
+The main integration hook. Returns `authorizeAndSend`.
+
+```ts
+const { authorizeAndSend } = useTrana()
+```
+
+#### `authorizeAndSend(options)`
+
+Builds the full proof, shows the modal, and sends the transaction.
+
+```ts
+// Minimal — SDK derives intent from the instruction automatically
+await authorizeAndSend({
+  instruction: withdrawIx,
+  label:       "Withdraw 1.5 SOL",
+})
+
+// Custom transaction — priority fees, extra instructions
+await authorizeAndSend({
+  instruction: withdrawIx,
+  label:       "Withdraw 1.5 SOL",
+  buildTransaction: async ({ recentBlockhash }) => {
+    const tx = new Transaction({ recentBlockhash, feePayer: wallet.publicKey })
+    tx.add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 5_000 }))
+    tx.add(withdrawIx)
+    return tx
+  },
+})
+```
+
+**What the SDK does automatically:**
+1. Simulates the transaction to detect which policy fires
+2. Fetches the `PasskeyRegistry` PDA (nonce, registered keys)
+3. Computes the intent hash (SHA-256 binding all accounts, params, nonce, expiry)
+4. Shows the confirmation modal for the user to review
+5. Triggers `navigator.credentials.get()` — the OS biometric prompt
+6. Constructs `secp256r1Ix` and `recordProofIx`
+7. Inserts the pair immediately before `instruction` in the final transaction
+8. Signs with the wallet and sends
+
+| Option | Type | Required | Description |
+|---|---|---|---|
+| `instruction` | `TransactionInstruction` | Yes | The protected instruction |
+| `label` | `string` | No | Human-readable action name shown in the modal |
+| `buildTransaction` | `async ({ recentBlockhash }) => Transaction` | No | Override transaction construction |
+
+---
+
+### `useTranaPasskeys`
+
+Lists the passkeys registered for the connected wallet and tracks backup status.
+
+```ts
+const { passkeys, hasBackup, isLoading } = useTranaPasskeys()
+
+// passkeys — PasskeyEntry[]
+// passkeys[0].credentialId  — Uint8Array
+// passkeys[0].pubkeyBytes   — Uint8Array (compressed P-256)
+// hasBackup — true when passkeys.length >= 2
+// isLoading — true while fetching registry
+```
+
+The hook subscribes to the `PasskeyRegistry` account and updates automatically when keys are added or removed.
+
+---
+
+### `useBackupNudge`
+
+Shows a one-time prompt after the first successful authorization to encourage adding a backup passkey.
+
+```tsx
+import { useBackupNudge } from "@tranaprotocol/sdk"
+
+function App() {
+  const { show, dismiss, openKeyManagement } = useBackupNudge({
+    onOpen: () => setKeyMgmtVisible(true),
+  })
+
+  return (
+    <>
+      {show && (
+        <BackupBanner
+          onDismiss={dismiss}
+          onSetupBackup={openKeyManagement}
+        />
+      )}
+    </>
+  )
+}
+```
+
+`show` is `true` once, 2 seconds after the first approval. Dismissal is stored in `localStorage` — the banner will not reappear in the same browser profile.
+
+---
+
+## `TranaGuardClient`
+
+Low-level client for the `trana_guard` program. Use this for passkey registration and management. Most apps only need this for the registration flow — `authorizeAndSend` handles enforcement automatically.
+
+```ts
+import { TranaGuardClient } from "@tranaprotocol/sdk/guard"
+
+const client = new TranaGuardClient({
+  connection,
+  cluster: "devnet",  // "devnet" | "localnet" | "mainnet-beta" | "custom"
+})
+```
+
+### Account derivation
+
+```ts
+// PasskeyRegistry PDA for a wallet
+const registryPda = client.registryPda(ownerPubkey)
+
+// TranaConfig (global fee config) PDA
+const configPda = client.configPda()
+```
+
+### Fetch accounts
+
+```ts
+// Read a wallet's PasskeyRegistry
+const registry = await client.fetchRegistry(ownerPubkey)
+// registry.nonce          — u64 (as bigint)
+// registry.keys           — PasskeyEntry[]
+// registry.keys[0].pubkeyBytes   — Uint8Array
+// registry.keys[0].credentialId  — Uint8Array
+
+// Read global fee config
+const config = await client.fetchConfig()
+// config.registerFee — bigint (lamports)
+// config.addKeyFee   — bigint (lamports)
+// config.treasury    — PublicKey
+```
+
+### `registerPasskey`
+
+Creates the `PasskeyRegistry` PDA and stores the first P-256 key. Call once per wallet. Triggers the OS passkey creation dialog.
+
+```ts
+const { instruction, handle } = await client.registerPasskey({
+  owner:           walletPubkey,
+  rpId:            window.location.hostname,
+  userDisplayName: walletPubkey.toBase58().slice(0, 8),
+})
+
+// instruction — TransactionInstruction (no proof required)
+// handle.pubkeyBytes  — compressed P-256 public key
+// handle.credentialId — WebAuthn credential ID (store this)
+
+const tx = new Transaction().add(instruction)
+await sendAndConfirm(tx)
+```
+
+### `addPasskey`
+
+Adds a backup passkey. Requires an existing key for authorization. Triggers two OS dialogs: new device registration, then existing device authentication.
+
+```ts
+const { secp256r1Ix, recordProofIx, instruction, handle } = await client.addPasskey({
+  owner:           walletPubkey,
+  credentialId,    // existing passkey's credential ID
+  rpId:            window.location.hostname,
+  userDisplayName: "Backup iPhone",
+})
+
+// Transaction must include all three in order
+const tx = new Transaction().add(secp256r1Ix, recordProofIx, instruction)
+await sendAndConfirm(tx)
+```
+
+### `removePasskey`
+
+Removes a passkey. Must be authorized by a **different** registered key. Cannot remove the last key.
+
+```ts
+const { secp256r1Ix, recordProofIx, instruction } = await client.removePasskey({
+  owner:                   walletPubkey,
+  credentialIdToRemove:    lostHandle.credentialId,
+  authorizingCredentialId: otherHandle.credentialId,
+  rpId:                    window.location.hostname,
+})
+
+const tx = new Transaction().add(secp256r1Ix, recordProofIx, instruction)
+await sendAndConfirm(tx)
+```
+
+### `buildProof`
+
+Build the `(secp256r1Ix, recordProofIx)` pair manually, without sending a transaction.
+
+```ts
+const { secp256r1Ix, recordProofIx } = await client.buildProof({
+  owner,
+  credentialId,
+  intent,         // TranaIntent — from buildIntent() or intentFromInstruction()
+  rpId:           window.location.hostname,
+})
+```
+
+---
+
+## `TranaAuthorityClient`
+
+Client for the `trana_authority` program. See [Authority](/authority) for the full workflow.
+
+```ts
+import { TranaAuthorityClient } from "@tranaprotocol/sdk/authority"
+
+const client = new TranaAuthorityClient({
+  connection,
+  cluster: "devnet",
+})
+```
+
+### Account derivation
+
+```ts
+const [pda, bump] = await client.recordPda(ownerPubkey, targetPubkey)
+```
+
+### Fetch account
+
+```ts
+const record = await client.fetchRecord(ownerPubkey, targetPubkey)
+// record.owner  — PublicKey
+// record.target — PublicKey
+// record.bump   — number
+```
+
+### `register`
+
+Creates the `AuthorityRecord` PDA. No passkey required.
+
+```ts
+const instruction = await client.register({
+  owner:  walletPubkey,
+  target: programPubkey,
+})
+```
+
+### `executeUpgrade`
+
+Builds the `execute_upgrade` instruction. Requires passkey proof — pass to `authorizeAndSend`.
+
+```ts
+const instruction = await client.executeUpgrade({
+  owner:       walletPubkey,
+  program:     programPubkey,
+  programData: programDataPubkey,
+  buffer:      bufferPubkey,
+  spill:       walletPubkey,
+})
+```
+
+### `reclaimAuthority`
+
+Builds the `reclaim_authority` instruction. Requires passkey proof.
+
+```ts
+const instruction = await client.reclaimAuthority({
+  owner:        walletPubkey,
+  target:       programPubkey,
+  programData:  programDataPubkey,
+  newAuthority: newAuthorityPubkey,
+})
+```
+
+---
+
+## Core utilities
+
+Import individually from `@tranaprotocol/sdk`:
+
+### Intent construction
+
+```ts
+import {
+  buildIntent,
+  hashIntent,
+  intentFromInstruction,
+} from "@tranaprotocol/sdk"
+```
+
+#### `buildIntent(input, opts)`
+
+Builds a `TranaIntent` — the structured object that gets hashed into the WebAuthn challenge.
+
+```ts
+const intent = buildIntent(
+  {
+    targetProgramId:           programPubkey,
+    instructionDiscriminator:  discriminator,  // 8-byte Anchor discriminator
+    accounts:                  instruction.keys.map(k => k.pubkey),
+    params:                    Buffer.from(instruction.data).slice(8),
+    policy:                    "trana.limit",
+  },
+  {
+    wallet:              walletPubkey,
+    tranaGuardProgramId: guardPubkey,
+    nonce:               registry.nonce,
+    expiryUnix:          Math.floor(Date.now() / 1000) + 120,
+  }
+)
+```
+
+#### `hashIntent(intent)`
+
+Returns the 32-byte SHA-256 of the intent — this is the WebAuthn challenge.
+
+```ts
+const challenge: Uint8Array = hashIntent(intent)
+```
+
+#### `intentFromInstruction(instruction, opts)`
+
+Derive intent directly from a `TransactionInstruction`.
+
+```ts
+const intent = intentFromInstruction(withdrawIx, {
+  wallet, tranaGuardProgramId, nonce, expiryUnix,
+})
+```
+
+---
+
+### Secp256r1 / proof construction
+
+```ts
+import {
+  buildSecp256r1Ix,
+  buildWebAuthnMessage,
+  buildRecordProofIx,
+} from "@tranaprotocol/sdk"
+```
+
+#### `buildSecp256r1Ix(pubkeyBytes, signature, message)`
+
+Constructs the SIMD-0075 native P-256 verification instruction.
+
+```ts
+const secp256r1Ix = buildSecp256r1Ix(
+  pubkeyBytes,   // 33-byte compressed P-256 public key
+  signature,     // 64-byte r‖s (low-S normalized)
+  message,       // authenticatorData ‖ SHA-256(clientDataJSON)
+)
+```
+
+#### `buildWebAuthnMessage(authenticatorData, clientDataJSON)`
+
+Constructs the message that was actually signed by the authenticator.
+
+```ts
+const message = buildWebAuthnMessage(authenticatorData, clientDataJSON)
+// returns: authenticatorData ‖ SHA-256(clientDataJSON)
+```
+
+#### `buildRecordProofIx(opts)`
+
+Constructs the `record_proof` data-carrier instruction.
+
+```ts
+const recordProofIx = buildRecordProofIx({
+  guardProgramId,
+  registryPubkey,
+  authenticatorData,
+  clientDataJSON,
+  expiryUnix,
+  policyId: "trana.limit",
+})
+```
+
+---
+
+### WebAuthn browser API
+
+```ts
+import { registerPasskey, signIntent } from "@tranaprotocol/sdk"
+```
+
+These are thin wrappers around `navigator.credentials.create()` and `navigator.credentials.get()`. Browser-only — do not call from Node.js.
+
+#### `registerPasskey(opts)`
+
+```ts
+const { pubkeyBytes, credentialId } = await registerPasskey({
+  rpId:            window.location.hostname,
+  userDisplayName: "My Wallet",
+  userId:          walletPubkey.toBytes(),
+})
+```
+
+#### `signIntent(credentialId, challenge, rpId)`
+
+```ts
+const { signature, authenticatorData, clientDataJSON } = await signIntent(
+  credentialId,
+  intentHash,    // 32-byte Uint8Array — the WebAuthn challenge
+  rpId,
+)
+```
+
+---
+
+## Types
+
+### `TranaCluster`
+
+```ts
+type TranaCluster = "devnet" | "localnet" | "mainnet-beta" | "custom"
+```
+
+### `PasskeyHandle`
+
+```ts
+type PasskeyHandle = {
+  pubkeyBytes:  Uint8Array   // 33-byte compressed P-256 public key
+  credentialId: Uint8Array   // WebAuthn credential ID (variable length, ≤128 bytes)
+}
+```
+
+### `Policy`
+
+```ts
+type Policy =
+  | { require: {} }
+  | { notBefore: { slot: bigint } }
+  | { notAfter:  { slot: bigint } }
+  | { limit: { paramOffset: number; limit: bigint } }
+```
+
+Convenience constructors:
+
+```ts
+import { Policy } from "@tranaprotocol/sdk"
+
+Policy.require()
+Policy.limit({ paramOffset: 0, limit: 1_000_000_000n })
+Policy.notBefore({ slot: 350_000_000n })
+Policy.notAfter({ slot: 350_000_000n })
+```
+
+### `TranaIntent`
+
+```ts
+type TranaIntent = {
+  version:                  1
+  domain:                   "trana:v1"
+  wallet:                   string       // base58
+  tranaGuardProgramId:      string
+  targetProgramId:          string
+  policyId:                 string       // "trana.require" | "trana.limit" | ...
+  instructionDiscriminator: string       // hex
+  accountsHash:             string       // hex SHA-256
+  paramsHash:               string       // hex SHA-256
+  nonce:                    string       // decimal u64
+  expiryUnix:               number       // unix timestamp
+  rawParamsHex:             string
+  accountsCount:            number
+}
+```
+
+---
+
+## Program IDs
+
+```ts
+import { PROGRAM_IDS } from "@tranaprotocol/sdk"
+
+PROGRAM_IDS["mainnet-beta"].guard      // GYhng7fbz51319ZwD1uBunBZs777C3KjmS52rYRcKfXn
+PROGRAM_IDS["mainnet-beta"].authority  // KoXvrg4DBLKa5U6LCUpWXJE1FHYqwaozqDqDcBXvGEE
+PROGRAM_IDS["devnet"].guard
+PROGRAM_IDS["devnet"].authority
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,13 @@
         "postcss": "^8.5.0",
         "tailwindcss": "^4.2",
         "typescript": "^5.7.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@napi-rs/simple-git-linux-x64-gnu": "0.1.22",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
+        "lightningcss-linux-x64-gnu": "1.32.0"
       }
     },
     "apps/landing/node_modules/@headlessui/react": {
@@ -2871,6 +2878,44 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
     "node_modules/@internationalized/date": {
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
@@ -4139,6 +4184,22 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/simple-git-linux-x64-gnu": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@napi-rs/simple-git-linux-x64-gnu/-/simple-git-linux-x64-gnu-0.1.22.tgz",
+      "integrity": "sha512-Ei1tM5Ho/dwknF3pOzqkNW9Iv8oFzRxE8uOhrITcdlpxRxVrBVptUF6/0WPdvd7R9747D/q61QG/AVyWsWLFKw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">= 10"
@@ -10117,6 +10178,22 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
+      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">= 20"
@@ -20018,6 +20095,26 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">= 12.0.0"

--- a/packages/sdk/tsconfig.build.json
+++ b/packages/sdk/tsconfig.build.json
@@ -12,11 +12,7 @@
     "strict":           true,
     "esModuleInterop":  true,
     "skipLibCheck":     true,
-    "resolveJsonModule": true,
-    "baseUrl":          ".",
-    "paths": {
-      "@noble/curves/nist": ["../../node_modules/@noble/curves/nist.d.ts"]
-    }
+    "resolveJsonModule": true
   },
   "include": [
     "src/index.ts",


### PR DESCRIPTION
## Summary

- **New `docs/content/authority.mdx`** — full `trana_authority` reference: setup, instructions, account schema, security model, multisig comparison, and upcoming PDA guarding section
- **New `docs/content/sdk.mdx`** — complete SDK reference: `TranaGuardClient`, `TranaAuthorityClient`, React hooks, core utilities, types, program IDs
- **Updated `_meta.ts`** — added `authority` and `sdk` to the nav
- **Updated `index.mdx`** — surfaces both programs with comparison table, policies table, updated links, and PDA guarding callout
- **Updated `architecture.mdx`** — fixed instruction count (5→7), added `trana_authority` program section and `authority/client.ts` to SDK tree
- **Updated `glossary.mdx`** — 8 new terms: `AuthorityRecord`, `execute_upgrade`, `reclaim_authority`, `BPF Loader Upgradeable`, `init_config`, `update_config`, `trana_authority`, `TranaConfig`
- **fix: Vercel native package failures** — lockfile was macOS-generated; added `optionalDependencies` for 5 Linux x64 native packages (`lightningcss`, `@tailwindcss/oxide`, `@napi-rs/simple-git`, `@img/sharp`, `@img/sharp-libvips`) and regenerated `package-lock.json`
- **fix: SDK `tsconfig.build.json` TS5101** — removed deprecated `baseUrl`+`paths`; `moduleResolution: bundler` resolves `@noble/curves/nist` directly
- **fix: `vault.ts` type error** — `concat()` now returns `Buffer` instead of `Uint8Array` to satisfy `TransactionInstruction.data`

## Test plan

- [ ] Vercel build completes without native binding errors
- [ ] SDK builds clean (`npm run build -w @tranaprotocol/sdk`)
- [ ] Docs pages render: `/authority`, `/sdk`, updated `/`, `/architecture`, `/glossary`

https://claude.ai/code/session_01B5gFFw4ytCH6xS7d6FcRh7

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5gFFw4ytCH6xS7d6FcRh7)_